### PR TITLE
Add an exception in the test suite for multiple Rgurobi versions in the same toolchain

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -331,8 +331,8 @@ class EasyConfigTest(TestCase):
                 dep_vars = dict((k, v) for (k, v) in dep_vars.items() if k != empty_vsuff_vars[0])
 
         # multiple variants of HTSlib is OK as long as they are deps for a matching version of BCFtools;
-        # same goes for WRF and WPS
-        for dep_name, parent_name in [('HTSlib', 'BCFtools'), ('WRF', 'WPS')]:
+        # same goes for WRF and WPS; Gurobi and Rgurobi
+        for dep_name, parent_name in [('HTSlib', 'BCFtools'), ('WRF', 'WPS'), ('Gurobi', 'Rgurobi')]:
             if dep == dep_name and len(dep_vars) > 1:
                 for key in list(dep_vars):
                     ecs = dep_vars[key]


### PR DESCRIPTION
@smoretti This collapses https://github.com/easybuilders/easybuild-easyconfigs/pull/14568 into https://github.com/easybuilders/easybuild-easyconfigs/pull/14525

When this is merged, please close https://github.com/easybuilders/easybuild-easyconfigs/pull/14568